### PR TITLE
Add homepage for bot

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, Response
+from flask import Flask, request, Response, render_template
 import json
 import requests
 import os
@@ -8,6 +8,10 @@ SLACK_BOT_USERNAME = os.environ['SLACK_BOT_USERNAME']
 CHANNEL_ID = os.environ['CHANNEL_ID']
 
 app = Flask(__name__)
+
+@app.route('/')
+def home():
+    return render_template('home.html')
 
 @app.route("/slack", methods=['POST'])
 def inbound():

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>GreetingBot | Civic Tech Toronto</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.2/gh-fork-ribbon.min.css" />
+    <style>
+      body {
+          padding-top: 2rem;
+            padding-bottom: 2rem;
+      }
+      h3 {
+          margin-top: 2rem;
+      }
+      .row {
+          margin-bottom: 1rem;
+      }
+      .row .row {
+          margin-top: 1rem;
+            margin-bottom: 0;
+      }
+      [class*="col-"] {
+          padding-top: 1rem;
+            padding-bottom: 1rem;
+              background-color: rgba(86,61,124,.15);
+                border: 1px solid rgba(86,61,124,.2);
+      }
+      hr {
+          margin-top: 2rem;
+            margin-bottom: 2rem;
+      }
+    </style>
+  </head>
+  <body>
+    <a class="github-fork-ribbon" href="https://github.com/CivicTechTO/slack-greeting-bot" data-ribbon="Contribute on GitHub" title="Contribute on GitHub">Contribute on GitHub</a>
+    <div class="container">
+      <h1>Hello, human!</h1>
+      <p class="lead">
+        I am the Civic Tech Toronto greetingbot, for welcoming people to Slack channels.
+      </p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Just so it has a front-facing identity to know that it's running correctly. Can be self-documenting if/when this becomes more full-featured.